### PR TITLE
feat: Allow any provider type

### DIFF
--- a/server/createWeb3.js
+++ b/server/createWeb3.js
@@ -3,10 +3,7 @@ const Web3 = require('web3')
 
 /* :: string -> Web3 */
 const createWeb3 = (ethereumJsonRPC) => {
-  const provider = new Web3.providers.HttpProvider(ethereumJsonRPC)
-  const web3 = new Web3(provider)
-
-  return web3
+  return new Web3(ethereumJsonRPC)
 }
 
 module.exports = createWeb3


### PR DESCRIPTION
Currently we needlessly enforce provider type `HttpProvider`

This should allow any provider type.